### PR TITLE
Use more conservative gas values

### DIFF
--- a/services/sputnik/SputnikNearService/services/SputnikDaoService.ts
+++ b/services/sputnik/SputnikNearService/services/SputnikDaoService.ts
@@ -13,7 +13,7 @@ import { DEFAULT_PROPOSAL_GAS } from 'services/sputnik/constants';
 
 import { SputnikWalletService } from './SputnikWalletService';
 
-export const GAS_VALUE = new BN('300000000000000');
+export const GAS_VALUE = new BN('100000000000000');
 
 export class SputnikDaoService {
   private readonly sputnikWalletService: SputnikWalletService;

--- a/services/sputnik/constants.ts
+++ b/services/sputnik/constants.ts
@@ -2,4 +2,4 @@ export const YOKTO_NEAR = 1000000000000000000000000;
 
 export const LIST_LIMIT_DEFAULT = 20;
 
-export const DEFAULT_PROPOSAL_GAS = 0.25;
+export const DEFAULT_PROPOSAL_GAS = 0.1;


### PR DESCRIPTION
Even most expensive calls seem to use far less than 300 Tgas (e.g. see https://explorer.near.org/transactions/7Wh4NL7JuzFgcu5HvhJs2xorrXi6ZSi93D9T695v9nFN)

But attaching 300 (or even 250) Tgas leaves no space for extra gas if using multisig/2FA account.

Fixes https://github.com/near-daos/astro-ui/issues/228