### PR TITLE
Fix: missing valid combinations in policy permissions

### DIFF
--- a/astro_2.0/features/CreateProposal/createProposalHelpers.ts
+++ b/astro_2.0/features/CreateProposal/createProposalHelpers.ts
@@ -1,6 +1,8 @@
 import { DAO } from 'types/dao';
-import { ProposalType, ProposalVariant } from 'types/proposal';
+import { ProposalType, ProposalActions, ProposalVariant } from 'types/proposal';
+import { APP_TO_CONTRACT_PROPOSAL_TYPE } from 'utils/dataConverter';
 import { ProposalPermissions } from 'types/context';
+import { PolicyType } from 'types/policy';
 
 export function isUserPermittedToCreateProposal(
   accountId: string | null | undefined,
@@ -38,13 +40,51 @@ export function isUserPermittedToCreateProposal(
   return matched;
 }
 
+// check if user can perform some action on some proposal kind
+export function checkUserPermission(
+  accountId: string,
+  policy: PolicyType,
+  userHasDelegatedTokens: boolean,
+  givenAction: ProposalActions,
+  givenProposalType: ProposalType
+): boolean {
+  // get all the user's permissions on the chosen proposal kind
+  const proposalKindPermissions: string[] = policy.roles
+    .filter(
+      role =>
+        role.kind === 'Everyone' ||
+        role.accountIds?.includes(accountId) ||
+        (role.kind === 'Member' && userHasDelegatedTokens)
+    )
+    .map(role => role.permissions)
+    .flat()
+    .filter(permission => {
+
+      const [proposalKind, action] = permission.split(':');
+
+      return (
+        proposalKind === '*' ||
+        proposalKind === APP_TO_CONTRACT_PROPOSAL_TYPE[givenProposalType]
+      );
+    });
+  // check if the user can perform the action on the proposal kind
+  const canDoAction: boolean = proposalKindPermissions?.some(permission => {
+    
+    const [proposalKind, action] = permission.split(':');
+    
+    return action === '*' || action === givenAction;
+  });
+
+  return canDoAction;
+}
+
 export function getAllowedProposalsToCreate(
   accountId: string | null | undefined,
   dao: DAO | null,
   userHasDelegatedTokens: boolean
 ): ProposalPermissions {
   // Restrict create by default
-  const result = {
+  const result: getAllowedProposalsResultType = {
     [ProposalType.ChangeConfig]: false,
     [ProposalType.ChangePolicy]: false,
     [ProposalType.AddBounty]: false,
@@ -64,89 +104,18 @@ export function getAllowedProposalsToCreate(
     return result;
   }
 
-  // Iterate through roles and try to find relevant permissions in user's roles
-  dao?.policy.roles.forEach(role => {
-    if (
-      role.kind === 'Everyone' ||
-      role.accountIds?.includes(accountId) ||
-      (role.kind === 'Member' && userHasDelegatedTokens)
-    ) {
-      role.permissions.forEach(permission => {
-        switch (permission) {
-          case '*:*':
-          case '*:AddProposal': {
-            result[ProposalType.ChangeConfig] = true;
-            result[ProposalType.ChangePolicy] = true;
-            result[ProposalType.AddBounty] = true;
-            result[ProposalType.BountyDone] = true;
-            result[ProposalType.FunctionCall] = true;
-            result[ProposalType.Transfer] = true;
-            result[ProposalType.Vote] = true;
-            result[ProposalType.RemoveMemberFromRole] = true;
-            result[ProposalType.AddMemberToRole] = true;
-            result[ProposalType.UpgradeRemote] = true;
-            result[ProposalType.UpgradeSelf] = true;
-            result[ProposalType.SetStakingContract] = true;
-            break;
-          }
-          case 'config:AddProposal': {
-            result[ProposalType.ChangeConfig] = true;
-            break;
-          }
-          case 'call:AddProposal': {
-            result[ProposalType.FunctionCall] = true;
-            break;
-          }
-          case 'bounty_done:AddProposal': {
-            result[ProposalType.BountyDone] = true;
-            break;
-          }
-          case 'policy:AddProposal': {
-            result[ProposalType.ChangePolicy] = true;
-            break;
-          }
-          case 'add_bounty:AddProposal': {
-            result[ProposalType.AddBounty] = true;
-            break;
-          }
-          case 'transfer:AddProposal': {
-            result[ProposalType.Transfer] = true;
-            break;
-          }
-          case 'vote:AddProposal': {
-            result[ProposalType.Vote] = true;
-            break;
-          }
-          case 'remove_member_from_role:AddProposal': {
-            result[ProposalType.RemoveMemberFromRole] = true;
-            break;
-          }
-          case 'add_member_to_role:AddProposal': {
-            result[ProposalType.AddMemberToRole] = true;
-            break;
-          }
-
-          // todo - temp disable some as they are hidden in ui
-          case 'upgrade_self:AddProposal': {
-            result[ProposalType.UpgradeSelf] = true;
-            break;
-          }
-          case 'upgrade_remote:AddProposal': {
-            result[ProposalType.UpgradeRemote] = true;
-            break;
-          }
-          case 'set_vote_token:AddProposal': {
-            result[ProposalType.SetStakingContract] = true;
-            break;
-          }
-
-          default: {
-            break;
-          }
-        }
-      });
-    }
-  });
+  if (dao?.policy) {
+    // Iterate through roles and try to find relevant permissions in user's roles
+    Object.keys(result).forEach(propType => {
+      result[<getAllowedProposalsResultKeyType>propType] = checkUserPermission(
+        accountId,
+        dao.policy,
+        userHasDelegatedTokens,
+        ProposalActions.AddProposal,
+        <getAllowedProposalsResultKeyType>propType
+      );
+    });
+  }
 
   return result;
 }
@@ -156,7 +125,7 @@ export function getAllowedProposalsToVote(
   dao: DAO | null
 ): ProposalPermissions {
   // Restrict create by default
-  const result = {
+  const result: getAllowedProposalsResultType = {
     [ProposalType.ChangeConfig]: false,
     [ProposalType.ChangePolicy]: false,
     [ProposalType.AddBounty]: false,
@@ -177,107 +146,37 @@ export function getAllowedProposalsToVote(
   }
 
   // Iterate through roles and try to find relevant permissions in user's roles
-  dao?.policy.roles.forEach(role => {
-    if (role.kind === 'Everyone' || role.accountIds?.includes(accountId)) {
-      role.permissions.forEach(permission => {
-        switch (permission) {
-          case '*:*':
-          case '*:VoteApprove':
-          case '*:VoteReject':
-          case '*:VoteRemove': {
-            result[ProposalType.ChangePolicy] = true;
-            result[ProposalType.AddBounty] = true;
-            result[ProposalType.Transfer] = true;
-            result[ProposalType.Vote] = true;
-            result[ProposalType.RemoveMemberFromRole] = true;
-            result[ProposalType.AddMemberToRole] = true;
-            break;
-          }
-          case 'config:VoteApprove':
-          case 'config:VoteReject':
-          case 'config:VoteRemove': {
-            result[ProposalType.ChangeConfig] = true;
-            break;
-          }
-
-          case 'bounty_done:VoteApprove':
-          case 'bounty_done:VoteReject':
-          case 'bounty_done:VoteRemove': {
-            result[ProposalType.BountyDone] = true;
-            break;
-          }
-
-          case 'call:VoteApprove':
-          case 'call:VoteReject':
-          case 'call:VoteRemove': {
-            result[ProposalType.FunctionCall] = true;
-            break;
-          }
-
-          case 'set_vote_token:VoteApprove':
-          case 'set_vote_token:VoteReject':
-          case 'set_vote_token:VoteRemove': {
-            result[ProposalType.SetStakingContract] = true;
-            break;
-          }
-
-          case 'upgrade_remote:VoteApprove':
-          case 'upgrade_remote:VoteReject':
-          case 'upgrade_remote:VoteRemove': {
-            result[ProposalType.UpgradeRemote] = true;
-            break;
-          }
-
-          case 'upgrade_self:VoteApprove':
-          case 'upgrade_self:VoteReject':
-          case 'upgrade_self:VoteRemove': {
-            result[ProposalType.UpgradeSelf] = true;
-            break;
-          }
-
-          case 'policy:VoteApprove':
-          case 'policy:VoteReject':
-          case 'policy:VoteRemove': {
-            result[ProposalType.ChangePolicy] = true;
-            break;
-          }
-          case 'add_bounty:VoteApprove':
-          case 'add_bounty:VoteReject':
-          case 'add_bounty:VoteRemove': {
-            result[ProposalType.AddBounty] = true;
-            break;
-          }
-          case 'transfer:VoteApprove':
-          case 'transfer:VoteReject':
-          case 'transfer:VoteRemove': {
-            result[ProposalType.Transfer] = true;
-            break;
-          }
-          case 'vote:VoteApprove':
-          case 'vote:VoteReject':
-          case 'vote:VoteRemove': {
-            result[ProposalType.Vote] = true;
-            break;
-          }
-          case 'remove_member_from_role:AddProposal':
-          case 'remove_member_from_role:VoteReject':
-          case 'remove_member_from_role:VoteRemove': {
-            result[ProposalType.RemoveMemberFromRole] = true;
-            break;
-          }
-          case 'add_member_to_role:AddProposal':
-          case 'add_member_to_role:VoteReject':
-          case 'add_member_to_role:VoteRemove': {
-            result[ProposalType.AddMemberToRole] = true;
-            break;
-          }
-          default: {
-            break;
-          }
-        }
-      });
-    }
-  });
+  if (dao?.policy) {
+    // Iterate through roles and try to find relevant permissions in user's roles
+    Object.keys(result).forEach(propType => {
+      // Can user VoteAppove or VoteRemove or VoteReject?
+      result[<getAllowedProposalsResultKeyType>propType] =
+        // check VoteApprove permission
+        checkUserPermission(
+          accountId,
+          dao.policy,
+          false,
+          ProposalActions.VoteApprove,
+          <getAllowedProposalsResultKeyType>propType
+        ) ||
+        // alternatively, check VoteReject permission
+        checkUserPermission(
+          accountId,
+          dao.policy,
+          false,
+          ProposalActions.VoteReject,
+          <getAllowedProposalsResultKeyType>propType
+        ) ||
+        // alternatively, check VoteRemove permission
+        checkUserPermission(
+          accountId,
+          dao.policy,
+          false,
+          ProposalActions.VoteRemove,
+          <getAllowedProposalsResultKeyType>propType
+        );
+    });
+  }
 
   return result;
 }
@@ -430,3 +329,19 @@ export function getInitialProposalVariant(
   // If user cannot create required proposals we return first available
   return getDefaultProposalVariantByType(allowedProposals[0]);
 }
+
+type getAllowedProposalsResultType = {
+  [ProposalType.ChangeConfig]: boolean;
+  [ProposalType.ChangePolicy]: boolean;
+  [ProposalType.AddBounty]: boolean;
+  [ProposalType.BountyDone]: boolean;
+  [ProposalType.FunctionCall]: boolean;
+  [ProposalType.Transfer]: boolean;
+  [ProposalType.Vote]: boolean;
+  [ProposalType.RemoveMemberFromRole]: boolean;
+  [ProposalType.AddMemberToRole]: boolean;
+  [ProposalType.UpgradeRemote]: boolean;
+  [ProposalType.UpgradeSelf]: boolean;
+  [ProposalType.SetStakingContract]: boolean;
+};
+type getAllowedProposalsResultKeyType = keyof getAllowedProposalsResultType;

--- a/astro_2.0/features/CreateProposal/createProposalHelpers.ts
+++ b/astro_2.0/features/CreateProposal/createProposalHelpers.ts
@@ -59,7 +59,6 @@ export function checkUserPermission(
     .map(role => role.permissions)
     .flat()
     .filter(permission => {
-
       const [proposalKind, action] = permission.split(':');
 
       return (
@@ -69,9 +68,8 @@ export function checkUserPermission(
     });
   // check if the user can perform the action on the proposal kind
   const canDoAction: boolean = proposalKindPermissions?.some(permission => {
-    
     const [proposalKind, action] = permission.split(':');
-    
+
     return action === '*' || action === givenAction;
   });
 

--- a/astro_2.0/features/CreateProposal/tests/createProposalHelpers.spec.ts
+++ b/astro_2.0/features/CreateProposal/tests/createProposalHelpers.spec.ts
@@ -211,13 +211,19 @@ describe('createProposalHelpers', () => {
       expect(
         getAllowedProposalsToVote('123', getDao(permission, '123'))
       ).toEqual({
-        ...result,
         [ProposalType.ChangePolicy]: true,
+        [ProposalType.ChangeConfig]: true,
         [ProposalType.AddBounty]: true,
         [ProposalType.Transfer]: true,
         [ProposalType.Vote]: true,
         [ProposalType.RemoveMemberFromRole]: true,
         [ProposalType.AddMemberToRole]: true,
+        [ProposalType.AddMemberToRole]: true,
+        [ProposalType.FunctionCall]: true,
+        [ProposalType.UpgradeRemote]: true,
+        [ProposalType.UpgradeSelf]: true,
+        [ProposalType.SetStakingContract]: true,
+        [ProposalType.BountyDone]: true,
       });
     });
 
@@ -235,10 +241,10 @@ describe('createProposalHelpers', () => {
       ${'vote:VoteApprove'}                    | ${ProposalType.Vote}
       ${'vote:VoteReject'}                     | ${ProposalType.Vote}
       ${'vote:VoteRemove'}                     | ${ProposalType.Vote}
-      ${'remove_member_from_role:AddProposal'} | ${ProposalType.RemoveMemberFromRole}
-      ${'remove_member_from_role:AddProposal'} | ${ProposalType.RemoveMemberFromRole}
-      ${'remove_member_from_role:AddProposal'} | ${ProposalType.RemoveMemberFromRole}
-      ${'add_member_to_role:AddProposal'}      | ${ProposalType.AddMemberToRole}
+      ${'remove_member_from_role:VoteApprove'} | ${ProposalType.RemoveMemberFromRole}
+      ${'remove_member_from_role:VoteReject'}  | ${ProposalType.RemoveMemberFromRole}
+      ${'remove_member_from_role:VoteRemove'}  | ${ProposalType.RemoveMemberFromRole}
+      ${'add_member_to_role:VoteApprove'}      | ${ProposalType.AddMemberToRole}
       ${'add_member_to_role:VoteReject'}       | ${ProposalType.AddMemberToRole}
       ${'add_member_to_role:VoteRemove'}       | ${ProposalType.AddMemberToRole}
     `(

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "pascal-case": "^3.1.2",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
-    "prettier": "2.0.0",
+    "prettier": "^2.7.1",
     "sass": "^1.35.1",
     "sass-loader": "^12.1.0",
     "semantic-release": "^17.4.4",

--- a/types/proposal.ts
+++ b/types/proposal.ts
@@ -38,6 +38,24 @@ export enum ProposalType {
   Vote = 'Vote',
 }
 
+export enum ProposalActions {
+  /// Action to add proposal. Used internally.
+  AddProposal = 'AddProposal',
+  /// Action to remove given proposal. Used for immediate deletion in special cases.
+  RemoveProposal = 'RemoveProposal',
+  /// Vote to approve given proposal or bounty.
+  VoteApprove = 'VoteApprove',
+  /// Vote to reject given proposal or bounty.
+  VoteReject = 'VoteReject',
+  /// Vote to remove given proposal or bounty (because it's spam).
+  VoteRemove = 'VoteRemove',
+  /// Finalize proposal, called when it's expired to return the funds
+  /// (or in the future can be used for early proposal closure).
+  Finalize = 'Finalize',
+  /// Move a proposal to the hub to shift into another DAO.
+  MoveToHub = 'MoveToHub',
+}
+
 export enum ProposalVariant {
   ProposeTransfer = 'ProposeTransfer',
   ProposeCreateBounty = 'ProposeCreateBounty',

--- a/types/role.ts
+++ b/types/role.ts
@@ -7,7 +7,7 @@ export type ProposalAction =
   | 'VoteRemove'
   | 'MoveToHub';
 
-export type ProposalKind = 
+export type ContractProposalType = 
   | 'config'
   | 'policy'
   | 'add_member_to_role'
@@ -34,7 +34,7 @@ export interface DefaultVotePolicy {
   weight?: string;
 }
 
-export type DaoPermission = `${'*' | ProposalKind}:${'*' | ProposalAction}`;
+export type DaoPermission = `${'*' | ContractProposalType}:${'*' | ProposalAction}`;
 
 export type DaoRoleKind = 'Everyone' | 'Group' | 'Member';
 

--- a/types/role.ts
+++ b/types/role.ts
@@ -1,9 +1,30 @@
 export type ProposalAction =
   | 'Finalize'
   | 'AddProposal'
+  | 'RemoveProposal'
   | 'VoteApprove'
   | 'VoteReject'
-  | 'VoteRemove';
+  | 'VoteRemove'
+  | 'MoveToHub';
+
+export type ProposalKind = 
+  | 'config'
+  | 'policy'
+  | 'add_member_to_role'
+  | 'remove_member_from_role'
+  | 'call'
+  | 'upgrade_self'
+  | 'upgrade_remote'
+  | 'transfer'
+  | 'set_vote_token'
+  | 'add_bounty'
+  | 'bounty_done'
+  | 'vote'
+  | 'factory_info_update'
+  | 'policy_add_or_update_role'
+  | 'policy_remove_role'
+  | 'policy_update_default_vote_policy'
+  | 'policy_update_parameters';
 
 export interface DefaultVotePolicy {
   weightKind: string;
@@ -13,61 +34,7 @@ export interface DefaultVotePolicy {
   weight?: string;
 }
 
-export type DaoPermission =
-  | '*:*'
-  | '*:Finalize'
-  | '*:AddProposal'
-  | '*:VoteApprove'
-  | '*:VoteReject'
-  | '*:VoteRemove'
-  | 'config:AddProposal'
-  | 'policy:AddProposal'
-  | 'add_bounty:AddProposal'
-  | 'bounty_done:AddProposal'
-  | 'transfer:AddProposal'
-  | 'call:AddProposal'
-  | 'vote:AddProposal'
-  | 'remove_member_from_role:AddProposal'
-  | 'add_member_to_role:AddProposal'
-  | 'upgrade_self:AddProposal'
-  | 'upgrade_remote:AddProposal'
-  | 'set_vote_token:AddProposal'
-  | 'config:VoteApprove'
-  | 'call:VoteApprove'
-  | 'upgrade_self:VoteApprove'
-  | 'upgrade_remote:VoteApprove'
-  | 'set_vote_token:VoteApprove'
-  | 'bounty_done:VoteApprove'
-  | 'policy:VoteApprove'
-  | 'add_bounty:VoteApprove'
-  | 'transfer:VoteApprove'
-  | 'vote:VoteApprove'
-  | 'remove_member_from_role:VoteApprove'
-  | 'add_member_to_role:VoteApprove'
-  | 'config:VoteReject'
-  | 'call:VoteReject'
-  | 'upgrade_self:VoteReject'
-  | 'upgrade_remote:VoteReject'
-  | 'set_vote_token:VoteReject'
-  | 'bounty_done:VoteReject'
-  | 'policy:VoteReject'
-  | 'add_bounty:VoteReject'
-  | 'transfer:VoteReject'
-  | 'vote:VoteReject'
-  | 'remove_member_from_role:VoteReject'
-  | 'add_member_to_role:VoteReject'
-  | 'config:VoteRemove'
-  | 'call:VoteRemove'
-  | 'upgrade_self:VoteRemove'
-  | 'upgrade_remote:VoteRemove'
-  | 'set_vote_token:VoteRemove'
-  | 'bounty_done:VoteRemove'
-  | 'policy:VoteRemove'
-  | 'add_bounty:VoteRemove'
-  | 'transfer:VoteRemove'
-  | 'vote:VoteRemove'
-  | 'remove_member_from_role:VoteRemove'
-  | 'add_member_to_role:VoteRemove';
+export type DaoPermission = `${'*' | ProposalKind}:${'*' | ProposalAction}`;
 
 export type DaoRoleKind = 'Everyone' | 'Group' | 'Member';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14334,15 +14334,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-2.0.0.tgz"
-  integrity sha512-vI55PC+GFLOVtpwr2di1mYhJF36v+kztJov8sx3AmqbfdA+2Dhozxb+3e1hTgoV9lyhnVJFF3Z8GCVeMBOS1bA==
-
 prettier@^2.2.1:
   version "2.3.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-error@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
A permission is a string in the form of `${'*' | ProposalKind}:${'*' | ProposalAction}`. Current code enumerates many combinations for every Proposal kind and Action, however many valid combinations are missing, namely ones in the form of `ProposalKind:*`